### PR TITLE
add build step

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -108,6 +108,11 @@ on:
         type: boolean
         default: true
         required: false
+      statup_timeout:
+        description: "Timeout for startup test in seconds"
+        type: number
+        default: 180
+        required: false
     secrets:
       registry_password:
         description: "Docker registry password, defaults to GITHUB_TOKEN"
@@ -316,6 +321,7 @@ jobs:
         env:
           FILE: ${{ inputs.startup_compose_file }}
           IMAGE_ENV_NAME: ${{ inputs.startup_image_env_name }}
+          STARTUP_TIMEOUT: ${{ inputs.startup_timeout }}
         run: |
           if [[ -n "$IMAGE_ENV_NAME" ]]; then
             eval "export $IMAGE_ENV_NAME=$LOCAL_IMAGE"
@@ -323,7 +329,7 @@ jobs:
 
           echo '::group::docker compose up'
           docker compose --file "$FILE" build
-          timeout 3m docker compose --file "$FILE" up --wait
+          timeout "${STARTUP_TIMEOUT}s" docker compose --file "$FILE" up --wait
           EXIT_CODE=$?
           echo '::endgroup::'
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -322,7 +322,8 @@ jobs:
           fi
 
           echo '::group::docker compose up'
-          timeout 5m docker compose --file "$FILE" up --wait
+          docker compose --file "$FILE" build
+          timeout 3m docker compose --file "$FILE" up --wait
           EXIT_CODE=$?
           echo '::endgroup::'
 


### PR DESCRIPTION
we're currently seeing timeouts in the kafka processors startup tests as we're doing one large monolithic startup test. Not sure if this will resolve the issue but the idea would be to separate the building and running of the test: whereas, the `build` should not have a timeout and the `up` or test should.